### PR TITLE
Fix Spectrum typo

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -140,6 +140,6 @@ lastmod = ["lastmod", ":git", "date"]
 
 [[menu.footer_social]]
   weight = 30
-  name = "spektrum"
+  name = "spectrum"
   pre = "far fa-comments"
   url = "https://spectrum.chat/glsp/"


### PR DESCRIPTION
Fix typo for `spectrum`