### PR TITLE
Embed youtube video in privacy enhanced mode

### DIFF
--- a/content/documentation/video.md
+++ b/content/documentation/video.md
@@ -1,8 +1,8 @@
 +++
-fragment = "content"
-title = "Videos"
+fragment = "embed"
+date = "2018-11-19"
 weight = 110
+title = "Videos"
+media_source = "https://www.youtube-nocookie.com/embed/snb1UTSH3Zw"
+ratio = "16by9"
 +++
-<div style="text-align:center;">
-  <iframe width="560" height="315" src="https://www.youtube.com/embed/snb1UTSH3Zw" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
-</div>


### PR DESCRIPTION
Embed the youtube video on the documentation page with Youtube's enhanced privacy mode to avoid Youtube/Google cookies being stored by the embedded video.
Also embed the video using the `embed` fragment type.