### PR TITLE
Replace video with link, make compatible with Hugo 0.60+

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -15,6 +15,9 @@ googleAnalytics = "UA-155083212-2"
 [outputs]
   home = ["HTML", "JSON"]
 
+[markup.goldmark.renderer]
+  unsafe= true
+
 [frontmatter]
 date = ["date", "lastmod"]
 lastmod = ["lastmod", ":git", "date"]

--- a/content/documentation/content.md
+++ b/content/documentation/content.md
@@ -5,13 +5,19 @@ weight = 100
 +++
 
 <span style='display:block; text-align: center;'>
+
 We are continuously improving our documentation, in case you miss something, please [contact us]({{< relref  "/contact" >}})
+
 </span>
 
 <span style='display:block; text-align: center;'>
+
 Technical documentation can be found on the [GLSP GitHub](https://github.com/eclipse-glsp/glsp)
+
 </span>
 
 <span style='display:block; text-align: center;'>
+
 See [here for the available support options]({{< relref  "/support" >}})
+
 </span>

--- a/content/documentation/video.md
+++ b/content/documentation/video.md
@@ -1,8 +1,8 @@
 +++
-fragment = "embed"
-date = "2018-11-19"
-weight = 110
+fragment = "content"
 title = "Videos"
-media_source = "https://www.youtube-nocookie.com/embed/snb1UTSH3Zw"
-ratio = "16by9"
+weight = 110
 +++
+<span style='display:block; text-align: center;'>
+EclipseCon Europe 2018: <a target="_blank" href="https://www.youtube.com/watch?v=snb1UTSH3Zw">Towards a Graphical Language Server Protocol for Diagrams?</a>
+</span>


### PR DESCRIPTION
Hugo 0.60+ changed its markdown renderer which by default no longer allows inline HTML. I enabled inline html and added new lines to content.md because this is no necesary when mixing html and markdown.

Replaced the embedded video of Philip's EclipseCon talk and replaced with a link that opens in a new tab/window. This sis done to avoid cookies.