### PR TITLE
Update to latest syna

### DIFF
--- a/content/_index/hero.md
+++ b/content/_index/hero.md
@@ -14,8 +14,7 @@ subtitle = "Diagram editors in the web/cloud with GLSP!"
 
 [asset]
   image = "diagramanimated.gif"
-  width = "500px" # optional - will default to image width
-  height = "150px" # optional - will default to image height
+  width = "600px" # optional - will default to image width
 
 [[buttons]]
   text = "Features"


### PR DESCRIPTION
A hugo update between 0.68 and 0.73 contained incompatible changes with
the syna theme. We now update to the latest syna master.

Also the syna theme was updated to properly handle custom paths.
Therefore we no longer need our custom path fix and can go back to
consume the regular syna version.

The top gif was set to 150px height which seemingly was ignored before
and was now honored with the hugo & syna update. The gif is now sized
appropriately.