### PR TITLE
Add devcontainer to build and serve hugo page

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,38 @@
+# Update the NODE_VERSION arg in docker-compose.yml to pick a Node version: 10, 12, 14
+ARG NODE_VERSION=14
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
+
+# VARIANT can be either 'hugo' for the standard version or 'hugo_extended' for the extended version.
+ARG VARIANT=hugo
+# VERSION can be either 'latest' or a specific version number
+ARG VERSION=latest
+
+# Download Hugo
+RUN apt-get update && apt-get install -y ca-certificates openssl git curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    case ${VERSION} in \
+    latest) \
+    export VERSION=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}') ;;\
+    esac && \
+    echo ${VERSION} && \
+    case $(uname -m) in \
+    aarch64) \
+    export ARCH=ARM64 ;; \
+    *) \
+    export ARCH=64bit ;; \
+    esac && \
+    echo ${ARCH} && \
+    wget -O ${VERSION}.tar.gz https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${VARIANT}_${VERSION}_Linux-${ARCH}.tar.gz && \
+    tar xf ${VERSION}.tar.gz && \
+    mv hugo /usr/bin/hugo
+
+# Hugo dev server port
+EXPOSE 1313
+
+# [Optional] Uncomment this section to install additional OS packages you may want.
+#
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN sudo -u node npm install -g <your-package-list-here>

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -3,7 +3,7 @@ ARG NODE_VERSION=14
 FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
 
 # VARIANT can be either 'hugo' for the standard version or 'hugo_extended' for the extended version.
-ARG VARIANT=hugo
+ARG VARIANT=hugo_extended
 # VERSION can be either 'latest' or a specific version number
 ARG VERSION=latest
 

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,7 @@ FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
 # VARIANT can be either 'hugo' for the standard version or 'hugo_extended' for the extended version.
 ARG VARIANT=hugo_extended
 # VERSION can be either 'latest' or a specific version number
-ARG VERSION=latest
+ARG VERSION=0.81.0
 
 # Download Hugo
 RUN apt-get update && apt-get install -y ca-certificates openssl git curl && \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 			// Update VARIANT to pick hugo variant.
 			// Example variants: hugo, hugo_extended
 			// Rebuild the container if it already exists to update.
-			"VARIANT": "hugo",
+			"VARIANT": "hugo_extended",
 			// Update VERSION to pick a specific hugo version.
 			// Example versions: latest, 0.73.0, 0,71.1
 			// Rebuild the container if it already exists to update.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,40 @@
+{
+	"name": "Hugo",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update VARIANT to pick hugo variant.
+			// Example variants: hugo, hugo_extended
+			// Rebuild the container if it already exists to update.
+			"VARIANT": "hugo",
+			// Update VERSION to pick a specific hugo version.
+			// Example versions: latest, 0.73.0, 0,71.1
+			// Rebuild the container if it already exists to update.
+			"VERSION": "latest",
+			// Update NODE_VERSION to pick the Node.js version: 12, 14
+			"NODE_VERSION": "14",
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {
+		"html.format.templating": true,
+	},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"bungcip.better-toml",
+		"davidanson.vscode-markdownlint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		1313
+	],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
 			// Update VERSION to pick a specific hugo version.
 			// Example versions: latest, 0.73.0, 0,71.1
 			// Rebuild the container if it already exists to update.
-			"VERSION": "latest",
+			"VERSION": "0.81.0",
 			// Update NODE_VERSION to pick the Node.js version: 12, 14
 			"NODE_VERSION": "14",
 		}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,28 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Serve Drafts",
+            "type": "shell",
+            "command": "hugo server -D",
+            "group": {
+                "kind": "test",
+                "isDefault": true
+            },
+            "isBackground": true,
+            "problemMatcher": []
+        },
+        {
+            "label": "Build",
+            "type": "shell",
+            "command": "hugo",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "problemMatcher": []
+        }
+    ]
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ spec:
       - mountPath: /home/jenkins/.ssh
         name: volume-known-hosts
     - name: hugo
-      image: eclipsecbi/hugo_extended:0.78.1
+      image: eclipsecbi/hugo_extended:0.81.0
       imagePullPolicy: Always
       command:
       - cat

--- a/README.md
+++ b/README.md
@@ -6,19 +6,21 @@ Please check the [Syna documentation](https://about.okkur.org/syna/docs/). The S
 
 ## Quick start
 
-### Prerequisites
+### Open in VSCode dev container
 
-  * Get submodules `git submodule init && git submodule update`
-  * Install Hugo. You can skip step 1, 2 & 3 when you already have brew installed properly
-    1. `sudo apt install linuxbrew-wrapper`
-    2. `brew` (This will execute the first time setup)
-    3. [Add brew to your PATH](https://github.com/Homebrew/brew/blob/master/docs/Homebrew-on-Linux.md#install)
-    4. `brew install hugo`
+To avoid the need to install hugo on development machines, a VSCode dev container is provided that runs hugo in a docker container.
+
+* Get submodules `git submodule init && git submodule update`
+* Open the repository folder in VSCode
+* If not installed, install Microsoft's "Remote - Containers" extension with id `ms-vscode-remote.remote-containers`.
+* Open this repository in VSCode as a [Dev Container](https://code.visualstudio.com/docs/remote/containers#_quick-start-open-an-existing-folder-in-a-container):
+  * Open command palette (`F1` or `Ctrl+Shift+P`)
+  * Run `Remote-Containers: Reopen in Container`
 
 ### Development
 
-  * Start Hugo server via `hugo server` for development
-  * Build the website via `hugo` for deployment (the public folder ist deployed then)
+* Start Hugo server via `hugo server` for development or run task `Serve Drafts`
+* Build the website via `hugo` for deployment (the public folder ist deployed then) or run task `Build`
 
 ## Overview
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.production.environment]
-HUGO_VERSION = "0.78.1"
+HUGO_VERSION = "0.81.0"
 HUGO_ENV = "production"
 HUGO_ENABLEGITINFO = "true"
 
@@ -11,20 +11,20 @@ HUGO_ENABLEGITINFO = "true"
 command = "hugo --gc --minify --enableGitInfo"
 
 [context.split1.environment]
-HUGO_VERSION = "0.78.1"
+HUGO_VERSION = "0.81.0"
 HUGO_ENV = "production"
 
 [context.deploy-preview]
 command = "hugo --gc --minify --buildFuture -b $DEPLOY_PRIME_URL"
 
 [context.deploy-preview.environment]
-HUGO_VERSION = "0.78.1"
+HUGO_VERSION = "0.81.0"
 
 [context.branch-deploy]
 command = "hugo --gc --minify -b $DEPLOY_PRIME_URL"
 
 [context.branch-deploy.environment]
-HUGO_VERSION = "0.78.1"
+HUGO_VERSION = "0.81.0"
 
 [context.next.environment]
 HUGO_ENABLEGITINFO = "true"


### PR DESCRIPTION
To avoid having to install brew and hugo, this PR adds a devcontainer to this repo enabling to build and serve this page inside a container. Also it adds VSCode tasks for building and serving.

Based on https://github.com/microsoft/vscode-dev-containers/tree/main/containers/hugo (MIT)