### PR TITLE
#622 Add modelserver-glspjava-emf-theia template

### DIFF
--- a/content/documentation/gettingStarted/content.md
+++ b/content/documentation/gettingStarted/content.md
@@ -30,12 +30,17 @@ cd glsp-examples/project-templates
 ```
 
 Now select your preferred server language, source model format, and platform integration (see list below).
-Switch to the respective folder and follow its readme file.
+Switch to the respective folder and follow its README file.
 
 * [🖥️ Java ● 🗂️ EMF ● 🖼️ Theia -- `java-emf-theia`](https://github.com/eclipse-glsp/glsp-examples/tree/master/project-templates/java-emf-theia)
 * [🖥️ Node ● 🗂️ Custom JSON ● 🖼️ Theia -- `node-json-theia`](https://github.com/eclipse-glsp/glsp-examples/tree/master/project-templates/node-json-theia)
 * [🖥️ Node ● 🗂️ Custom JSON ● 🖼️ VS Code -- `node-json-vscode`](https://github.com/eclipse-glsp/glsp-examples/tree/master/project-templates/node-json-vscode)
 * [🖥️ Java ● 🗂️ EMF ● 🖼️ Eclipse -- `java-emf-eclipse`](https://github.com/eclipse-glsp/glsp-examples/tree/master/project-templates/java-emf-eclipse)
+
+If you would like to use an external source model managing component, you can use the [EMF.cloud Model Server](https://github.com/eclipse-emfcloud/emfcloud-modelserver/) component.
+Please see the following project-template and follow its README file.
+
+* [💾 Model Server ● 🖥️ Java ● 🗂️ EMF ● 🖼️ Theia -- `modelserver-glspjava-emf-theia`](https://github.com/eclipse-emfcloud/modelserver-glsp-integration/tree/main/project-templates/modelserver-glspjava-emf-theia)
 
 If you don't find your preferred combination, please raise a question in the [Github discussions](https://github.com/eclipse-glsp/glsp/discussions).
 If you need help on deciding which combination is right for you, please refer to the [integrations]({{< relref  "integrations" >}}) page or look at our [support options]({{< relref  "support" >}}).


### PR DESCRIPTION
Add modelserver-glspjava-emf-theia project template to Getting Started page

Part of https://github.com/eclipse-glsp/glsp/issues/622
Part of https://github.com/eclipse-emfcloud/modelserver-glsp-integration/issues/25