### PR TITLE
Add referrer- and permissions-policy to config

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -33,3 +33,5 @@ HUGO_ENABLEGITINFO = "true"
    for = "/*"
    [headers.values]
       Access-Control-Allow-Origin = "*"
+      Referrer-Policy = "no-referrer"
+      Permissions-Policy = "accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()"


### PR DESCRIPTION
Those two policies are missing according to https://securityheaders.com/?q=https%3A%2F%2Fwww.eclipse.org%2Fglsp%2F&hide=on&followRedirects=on