### PR TITLE
Document Model Context Protocol (MCP) support

### DIFF
--- a/content/documentation/mcp/content.md
+++ b/content/documentation/mcp/content.md
@@ -13,7 +13,7 @@ A GLSP server can optionally act as an MCP server, so that AI clients such as an
 
 In practice this lets an assistant answer questions about a diagram, suggest improvements, create or adjust elements from a natural-language request, or check the model for problems, all while the diagram stays open in the GLSP editor.
 
-<small>*Experimental: MCP support is under active development and its configuration may still change. It is currently available for the [Node GLSP server](https://github.com/eclipse-glsp/glsp-server-node) only, with [Java server support](https://github.com/eclipse-glsp/glsp/issues/1672) planned.*</small>
+<small>*Experimental: MCP support is under active development and its configuration may still change. It is currently available for the [Node GLSP server](https://github.com/eclipse-glsp/glsp-server-node) only.*</small>
 
 ### What it provides
 
@@ -27,9 +27,23 @@ Each MCP client connects over the standard MCP streamable HTTP transport and get
 
 ### Enabling MCP
 
-MCP is opt-in and off by default.
-An MCP-aware GLSP client enables it by adding an `mcpServer` configuration to the [initialize request]({{< relref "protocol" >}}) it already sends.
-The standalone workflow example, for instance, passes it through the diagram loader:
+MCP is opt-in and off by default. Enabling it has a server and a client part.
+
+**On the server**, add the `@eclipse-glsp/server-mcp` package and load its two modules in the GLSP server's DI configuration: a per-session diagram module and a launcher-level server module.
+
+```ts
+const serverModule = new MyServerModule().configureDiagramModule(
+    new MyDiagramModule(...),
+    new DefaultMcpDiagramModule()           // per-session MCP services
+);
+launcher.configure(serverModule, new NodeMcpServerModule()); // MCP HTTP server
+```
+
+The two modules bind into different scopes: the server module holds process-wide singletons such as the MCP server itself, while the diagram module is instantiated fresh for each open diagram.
+By subclassing the server module you set the deploy-time options that are kept off the initialize payload for security, such as the network binding and the host and origin allowlists.
+By subclassing the diagram module you bind the per-session services, such as the model serializer, label provider, and element-types provider, plus any diagram-scoped tools, resources, or prompts (see [Adapting it to your language](#adapting-it-to-your-language)).
+
+**On the client**, an MCP-aware GLSP client opts in by adding an `mcpServer` configuration to the [initialize request]({{< relref "protocol" >}}) it already sends. The standalone workflow example passes it through the diagram loader:
 
 ```ts
 diagramLoader.load<McpInitializeParameters>({
@@ -39,7 +53,7 @@ diagramLoader.load<McpInitializeParameters>({
 ```
 
 An empty `mcpServer: {}` enables MCP with all defaults.
-Its options such as the port, route, and name are documented in the [adopter guide](https://github.com/eclipse-glsp/glsp-server-node/blob/main/packages/server-mcp/README.md).
+Its options, such as the port, route, name, data-exposure mode, and agent persona, are documented in the [adopter guide](https://github.com/eclipse-glsp/glsp-server-node/blob/main/packages/server-mcp/README.md).
 
 ### Architecture
 
@@ -84,7 +98,8 @@ How the announced MCP server URL reaches the AI client depends on the platform:
 ### Security
 
 The shipped defaults assume a single trusted local process reaching the server over loopback, which is the typical desktop IDE setup.
-The server binds to loopback only and performs the standard Host and Origin checks to defeat DNS rebinding, but it ships with **no authentication**.
+The server binds to loopback only and performs the spec-mandated Host-header check to defeat DNS rebinding, but it ships with **no authentication**.
+Origin checking is available but off by default, since desktop MCP clients omit the Origin header.
 If an adopter widens the bind beyond loopback without acknowledging the missing authentication, the server refuses to start. Doing so safely requires an external authenticating layer such as a reverse proxy.
 The server is not hardened for hostile multi-tenant or public exposure.
 

--- a/content/documentation/mcp/content.md
+++ b/content/documentation/mcp/content.md
@@ -1,0 +1,95 @@
++++
+fragment = "content"
+weight = 100
+
+title = "Model Context Protocol (MCP)"
+
+[sidebar]
+  sticky = true
++++
+
+The [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open standard that lets AI agents and language models interact with external systems through a uniform interface.
+A GLSP server can optionally act as an MCP server, so that AI clients such as an IDE chat assistant can inspect and edit diagrams through the same interface they use for any other MCP integration.
+
+In practice this lets an assistant answer questions about a diagram, suggest improvements, create or adjust elements from a natural-language request, or check the model for problems, all while the diagram stays open in the GLSP editor.
+
+<small>*Experimental: MCP support is under active development and its configuration may still change. It is currently available for the [Node GLSP server](https://github.com/eclipse-glsp/glsp-server-node) only, with [Java server support](https://github.com/eclipse-glsp/glsp/issues/1672) planned.*</small>
+
+### What it provides
+
+A GLSP MCP server surfaces the active diagrams through the three MCP capability kinds:
+
+* 🛠️ **Tools** to inspect, query, create, modify, delete, validate, and navigate diagram elements.
+* 📦 **Resources** that expose read-only, URI-addressable views of a diagram, such as a rendered image.
+* 💬 **Prompts** that frame common multi-step agent tasks against the diagram.
+
+Each MCP client connects over the standard MCP streamable HTTP transport and gets its own session, guided by a built-in modeling agent persona toward safe use of the tools.
+
+### Enabling MCP
+
+MCP is opt-in and off by default.
+An MCP-aware GLSP client enables it by adding an `mcpServer` configuration to the [initialize request]({{< relref "protocol" >}}) it already sends.
+The standalone workflow example, for instance, passes it through the diagram loader:
+
+```ts
+diagramLoader.load<McpInitializeParameters>({
+    // opt in by adding mcpServer (all fields optional)
+    initializeParameters: { mcpServer: { name: 'glsp-workflow', port: 64577 } }
+});
+```
+
+An empty `mcpServer: {}` enables MCP with all defaults.
+Its options such as the port, route, and name are documented in the [adopter guide](https://github.com/eclipse-glsp/glsp-server-node/blob/main/packages/server-mcp/README.md).
+
+### Architecture
+
+<p align="center">
+<img src="mcp-architecture.svg" alt="High-level GLSP MCP architecture" width=700/>
+<br/>
+<b>High-level MCP architecture: the GLSP server starts an MCP server when a client opts in</b>
+</p>
+
+The MCP server runs inside each GLSP server, which is created per connecting application (in the common desktop setup, one per process).
+One GLSP server therefore has one MCP server on one port, and all of that server's diagrams are reached through it.
+
+The MCP server is not started eagerly.
+The GLSP server spawns it the first time a client opts into MCP, and disposes it when the GLSP server shuts down.
+The resolved URL is announced back to the client (and logged on the server's standard output), so the tool platform integration can register it with the MCP client.
+A random free port is used by default, but adopters can pin a fixed port when an external MCP client needs a stable URL.
+
+Besides this Node process model, the MCP server is portable: it can also run fully in the browser inside a Web Worker, so AI-assisted modeling works in pure web deployments of GLSP as well.
+
+### Adapting it to your language
+
+The built-in tools work on any GLSP model, but their default output is deliberately generic.
+A few language-specific adaptations give noticeably better results:
+
+* A custom **model serializer** controls how a diagram is presented to the model. The workflow example renders it as semantically ordered Markdown and drops redundant attributes, which improves comprehension and keeps the context small.
+* A custom **label provider** and **element-types provider** tell the model how elements are labeled and which element types it may create, so the built-in create and modify tools work for your language.
+
+The built-in write tools dispatch standard GLSP [operations]({{< relref "modelOperations" >}}), so they reuse a diagram's existing operation handlers and an assistant's edits follow the same validation and undo or redo as a manual one.
+Adopters therefore rarely need custom tools for editing, but they can add their own tools, resources, and prompts for language-specific actions.
+A tool always returns a human-readable text result and may additionally return a structured payload, so different MCP clients can consume whichever form they support.
+
+The workflow example demonstrates these provider overrides, and the [extension guide](https://github.com/eclipse-glsp/glsp-server-node/blob/main/packages/server-mcp/ARCHITECTURE.md) covers adding custom tools, resources, and prompts.
+
+### Tool platform integration
+
+How the announced MCP server URL reaches the AI client depends on the platform:
+
+* **Eclipse Theia**: the [Theia MCP integration](https://github.com/eclipse-glsp/glsp-theia-integration/tree/master/packages/theia-mcp-integration) registers every GLSP server's MCP endpoint with Theia's AI MCP support automatically, with no extra wiring beyond installing it.
+* **VS Code**: the [VS Code integration](https://github.com/eclipse-glsp/glsp-vscode-integration) provides an MCP server provider that adopters register in their extension and feed with the GLSP initialize result.
+* **Standalone or external clients**: tools such as Claude Desktop or the MCP Inspector connect to the announced URL directly. Pin a fixed port and share it in your setup guide.
+
+### Security
+
+The shipped defaults assume a single trusted local process reaching the server over loopback, which is the typical desktop IDE setup.
+The server binds to loopback only and performs the standard Host and Origin checks to defeat DNS rebinding, but it ships with **no authentication**.
+If an adopter widens the bind beyond loopback without acknowledging the missing authentication, the server refuses to start. Doing so safely requires an external authenticating layer such as a reverse proxy.
+The server is not hardened for hostile multi-tenant or public exposure.
+
+### Further reading
+
+* [server-mcp adopter guide](https://github.com/eclipse-glsp/glsp-server-node/blob/main/packages/server-mcp/README.md): the integration quickstart.
+* [server-mcp architecture and extension guide](https://github.com/eclipse-glsp/glsp-server-node/blob/main/packages/server-mcp/ARCHITECTURE.md): architecture, security model, configuration options, and the extension cookbook.
+* [MCP feature request (issue #1546)](https://github.com/eclipse-glsp/glsp/issues/1546): background and rationale.

--- a/content/documentation/mcp/index.md
+++ b/content/documentation/mcp/index.md
@@ -1,0 +1,4 @@
++++
+title = "Model Context Protocol"
+weight = 85
++++

--- a/content/documentation/mcp/mcp-architecture.svg
+++ b/content/documentation/mcp/mcp-architecture.svg
@@ -1,0 +1,49 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 400" font-family="'Helvetica Neue', Arial, sans-serif" role="img" aria-label="High-level GLSP MCP architecture">
+  <defs>
+    <marker id="arrow" markerWidth="9" markerHeight="9" refX="6.5" refY="3" orient="auto-start-reverse">
+      <path d="M0,0 L6.5,3 L0,6 Z" fill="#5b6b7b"/>
+    </marker>
+  </defs>
+
+  <!-- containers -->
+  <rect x="250" y="22" width="448" height="360" rx="9" fill="none" stroke="#9aa7b4" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <text x="264" y="42" font-size="12" fill="#5b6b7b" font-style="italic">GLSP server process</text>
+
+  <rect x="276" y="62" width="404" height="300" rx="8" fill="#fbfcfd" stroke="#9aa7b4" stroke-width="1.5" stroke-dasharray="5 4"/>
+  <text x="290" y="82" font-size="12" fill="#5b6b7b" font-style="italic">GLSP server — one per connected app</text>
+
+  <!-- client-side boxes -->
+  <rect x="28" y="44" width="172" height="48" rx="6" fill="#f5f7fa" stroke="#5b6b7b" stroke-width="1.5"/>
+  <text x="114" y="73" font-size="13" fill="#2d3a45" text-anchor="middle">AI agent / LLM</text>
+
+  <rect x="28" y="150" width="172" height="58" rx="6" fill="#f5f7fa" stroke="#5b6b7b" stroke-width="1.5"/>
+  <text x="114" y="174" font-size="13" fill="#2d3a45" text-anchor="middle">MCP client</text>
+  <text x="114" y="192" font-size="11" fill="#5b6b7b" text-anchor="middle">(Theia · VS Code · Claude)</text>
+
+  <rect x="28" y="300" width="172" height="58" rx="6" fill="#f5f7fa" stroke="#5b6b7b" stroke-width="1.5"/>
+  <text x="114" y="324" font-size="13" fill="#2d3a45" text-anchor="middle">GLSP client</text>
+  <text x="114" y="342" font-size="11" fill="#5b6b7b" text-anchor="middle">(diagram editor)</text>
+
+  <!-- server-side boxes -->
+  <rect x="300" y="150" width="178" height="58" rx="6" fill="#eaf3fb" stroke="#2b6cb0" stroke-width="1.5"/>
+  <text x="389" y="174" font-size="13" fill="#1c4e80" text-anchor="middle">MCP server</text>
+  <text x="389" y="192" font-size="11" fill="#3a6ea5" text-anchor="middle">(one per GLSP server)</text>
+
+  <rect x="300" y="300" width="178" height="58" rx="6" fill="#f5f7fa" stroke="#5b6b7b" stroke-width="1.5"/>
+  <text x="389" y="324" font-size="13" fill="#2d3a45" text-anchor="middle">Client sessions</text>
+  <text x="389" y="342" font-size="11" fill="#5b6b7b" text-anchor="middle">(one per open diagram)</text>
+
+  <!-- arrows -->
+  <line x1="114" y1="92" x2="114" y2="149" stroke="#5b6b7b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="120" y="125" font-size="11" fill="#5b6b7b">uses</text>
+
+  <line x1="201" y1="179" x2="299" y2="179" stroke="#5b6b7b" stroke-width="1.5" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+  <text x="250" y="171" font-size="11" fill="#5b6b7b" text-anchor="middle">MCP / HTTP</text>
+
+  <line x1="201" y1="329" x2="299" y2="329" stroke="#5b6b7b" stroke-width="1.5" marker-start="url(#arrow)" marker-end="url(#arrow)"/>
+  <text x="250" y="321" font-size="11" fill="#5b6b7b" text-anchor="middle">GLSP protocol</text>
+
+  <line x1="389" y1="209" x2="389" y2="299" stroke="#5b6b7b" stroke-width="1.5" marker-end="url(#arrow)"/>
+  <text x="399" y="250" font-size="11" fill="#5b6b7b">operates on</text>
+  <text x="399" y="264" font-size="11" fill="#5b6b7b">sessions</text>
+</svg>

--- a/content/documentation/protocol/content.md
+++ b/content/documentation/protocol/content.md
@@ -210,6 +210,68 @@ interface ServerActions {
 
 </details>
 
+**MCP Server Configuration** _(experimental)_
+
+A GLSP server can optionally expose a [Model Context Protocol (MCP)]({{< relref "mcp" >}}) server alongside the GLSP protocol, so that AI agents can query and modify the diagram. An MCP-aware client opts in by adding an `mcpServer` configuration to the `initialize` request. The **presence** of the `mcpServer` key is the opt-in signal: an empty object enables the MCP server with defaults, omitting the key disables it. Once started, the resolved MCP server URL is reported back via the `mcpServer` property of the `InitializeResult`. These extensions are experimental and may still change while the feature matures.
+
+<details open><summary>Code</summary>
+
+```typescript
+interface McpInitializeParameters extends InitializeParameters {
+    /**
+     * MCP server configuration. Its presence enables the MCP server;
+     * omitting the key disables it.
+     */
+    mcpServer?: McpServerConfiguration;
+}
+
+interface McpInitializeResult extends InitializeResult {
+    /**
+     * The announced MCP server (only present if MCP was opted in).
+     */
+    mcpServer: McpServerResult;
+}
+
+interface McpServerConfiguration {
+    /**
+     * Port the MCP server listens on. Defaults to 0 (a random free port).
+     */
+    port?: number;
+
+    /**
+     * HTTP route of the MCP endpoint (default '/mcp').
+     */
+    route?: string;
+
+    /**
+     * Name reported in the MCP server handshake.
+     */
+    name?: string;
+
+    // Additional behavioral options (e.g. the data exposure mode) are
+    // described in the MCP documentation.
+}
+
+interface McpServerResult {
+    /**
+     * The name of the MCP server.
+     */
+    name: string;
+
+    /**
+     * The URL at which the MCP server is accessible.
+     */
+    url: string;
+
+    /**
+     * Optional headers AI clients should include when connecting.
+     */
+    headers?: Record<string, string>;
+}
+```
+
+</details>
+
 **InitializeClientSession Request**
 
 When a new graphical representation (diagram) is created a `InitializeClientSession` request has to be sent to the server. Each individual diagram on the client side counts as one session and has to provide a unique `clientSessionId` and its `diagramType`. In addition, custom arguments can be provided in the `args` map to allow for custom initialization behavior on the server.
@@ -1008,6 +1070,8 @@ A `RequestExportSvgAction` is sent by the client (or the server) to initiate the
 The handler of this action is expected to retrieve the diagram SVG and should send an `ExportSvgAction` as response.
 Typically the `ExportSvgAction` is handled directly on client side.
 
+> **Deprecated.** Prefer the generic [`RequestExportAction`](#255-requestexportaction) / [`ExportResultAction`](#256-exportresultaction) pair, which also supports other formats such as PNG.
+
 <details open><summary>Code</summary>
 
 ```typescript
@@ -1034,6 +1098,8 @@ The expected result of executing an `ExportSvgAction` is a new file in SVG-forma
 However, other details like the target destination, concrete file name, file extension etc. are not specified in the protocol.
 So it is the responsibility of the action handler to process this information accordingly and export the result to the underlying filesystem.
 
+> **Deprecated.** Use [`ExportResultAction`](#256-exportresultaction) as the response to a generic [`RequestExportAction`](#255-requestexportaction) instead.
+
 <details open><summary>Code</summary>
 
 ```typescript
@@ -1059,6 +1125,93 @@ interface ExportSvgOptions {
      * If set to `false`, applied diagram styles are not copied to the exported SVG.
      */
     skipCopyStyles?: boolean;
+}
+```
+
+</details>
+
+#### 2.5.5. RequestExportAction
+
+A generic, format-agnostic export request. It is sent by the client to itself for UI-driven export flows, or from the server to the client for server-orchestrated flows (e.g. an MCP tool requesting a PNG snapshot of the active diagram). The expected response is an `ExportResultAction` carrying the rendered bytes. The package ships `svg` and `png` formats; adopters can register additional formats.
+
+<details open><summary>Code</summary>
+
+```typescript
+interface RequestExportAction extends RequestAction<ExportResultAction> {
+    kind = 'requestExport';
+
+    /**
+     * The requested export format, e.g. 'svg' or 'png'.
+     */
+    format: ExportFormat;
+
+    /**
+     * Format-specific options (e.g. `PngExportOptions` for PNG).
+     */
+    formatOptions?: unknown;
+}
+
+type ExportFormat = 'svg' | 'png' | string;
+
+interface PngExportOptions {
+    /**
+     * Output width in px.
+     */
+    width?: number;
+
+    /**
+     * Output height in px. Derived from the rendered aspect ratio if omitted.
+     */
+    height?: number;
+
+    /**
+     * CSS color painted as the canvas background before drawing the diagram.
+     */
+    background?: string;
+
+    /**
+     * If `false`, applied diagram styles are not copied before rasterizing.
+     */
+    skipCopyStyles?: boolean;
+}
+```
+
+</details>
+
+#### 2.5.6. ExportResultAction
+
+Response to a `RequestExportAction` carrying the rendered diagram. Text-encoded payloads (e.g. SVG markup) ride in `data` directly; binary payloads (e.g. PNG) are base64-encoded so the action stays JSON-safe.
+
+<details open><summary>Code</summary>
+
+```typescript
+interface ExportResultAction extends ResponseAction {
+    kind = 'exportResult';
+
+    /**
+     * Echoes the requested format.
+     */
+    format: ExportFormat;
+
+    /**
+     * MIME type of the data, e.g. 'image/svg+xml' or 'image/png'.
+     */
+    mimeType: string;
+
+    /**
+     * Encoding of `data`: 'text' for markup, 'base64' for binary blobs.
+     */
+    encoding: 'text' | 'base64' | string;
+
+    /**
+     * SVG markup ('text' encoding) or base64-encoded bytes ('base64' encoding).
+     */
+    data: string;
+
+    /**
+     * Echoes the request's `formatOptions`.
+     */
+    formatOptions?: unknown;
 }
 ```
 
@@ -1292,6 +1445,55 @@ interface FitToScreenAction extends Action {
      * Indicate if the action should be performed with animation support or not.
      */
     animate: boolean = true;
+}
+```
+
+</details>
+
+##### 2.8.1.3. OriginViewportAction
+
+Resets the viewport to its origin (zoom 1, scroll 0). This is typically dispatched by the client (e.g., from the tool palette) but can also be sent by the server to reset the viewport remotely.
+
+<details open><summary>Code</summary>
+
+```typescript
+interface OriginViewportAction extends Action {
+    /**
+     * The kind of the action.
+     */
+    kind = 'originViewport';
+
+    /**
+     * Indicate if the viewport change should be animated.
+     */
+    animate: boolean = true;
+}
+```
+
+</details>
+
+##### 2.8.1.4. MoveViewportAction
+
+Moves the diagram canvas by the given amount. This can be dispatched on the client or sent by the server to scroll the viewport remotely.
+
+<details open><summary>Code</summary>
+
+```typescript
+interface MoveViewportAction extends Action {
+    /**
+     * The kind of the action.
+     */
+    kind = 'moveViewport';
+
+    /**
+     * The amount to be moved in the x-axis.
+     */
+    moveX: number;
+
+    /**
+     * The amount to be moved in the y-axis.
+     */
+    moveY: number;
 }
 ```
 
@@ -1534,6 +1736,49 @@ interface SelectAllAction extends Action {
      * If `select` is true, all elements are selected, otherwise they are deselected.
      */
     select: boolean;
+}
+```
+
+</details>
+
+#### 2.8.4. Editor Context
+
+GLSP requests are bidirectional: in addition to the client querying the server, the server can also send request actions to the client and await a response. The optional `timeout` field on [`RequestAction`](#2121-requestaction) bounds how long the sender waits. A common case is the server asking the client for the current [`EditorContext`](#238-editorcontext) snapshot. More specific queries such as `GetSelectionAction` and `GetViewportAction` (reused from Sprotty) follow the same request/response pattern.
+
+##### 2.8.4.1. GetEditorContextAction
+
+Sent from the server to the client to request the current editor context. The response is an `EditorContextResult` carrying a snapshot of the client state at the time the response is generated.
+
+<details open><summary>Code</summary>
+
+```typescript
+interface GetEditorContextAction extends RequestAction<EditorContextResult> {
+    /**
+     * The kind of the action.
+     */
+    kind = 'getEditorContext';
+}
+```
+
+</details>
+
+##### 2.8.4.2. EditorContextResult
+
+Response to a `GetEditorContextAction` containing a snapshot of the client-side editor state. The server should not assume that these values are still current when it processes the response, as the client state may have changed in the meantime.
+
+<details open><summary>Code</summary>
+
+```typescript
+interface EditorContextResult extends ResponseAction {
+    /**
+     * The kind of the action.
+     */
+    kind = 'editorContextResult';
+
+    /**
+     * The editor context snapshot.
+     */
+    editorContext: EditorContext;
 }
 ```
 

--- a/content/documentation/protocol/content.md
+++ b/content/documentation/protocol/content.md
@@ -212,7 +212,14 @@ interface ServerActions {
 
 **MCP Server Configuration** _(experimental)_
 
-A GLSP server can optionally expose a [Model Context Protocol (MCP)]({{< relref "mcp" >}}) server alongside the GLSP protocol, so that AI agents can query and modify the diagram. An MCP-aware client opts in by adding an `mcpServer` configuration to the `initialize` request. The **presence** of the `mcpServer` key is the opt-in signal: an empty object enables the MCP server with defaults, omitting the key disables it. Once started, the resolved MCP server URL is reported back via the `mcpServer` property of the `InitializeResult`. These extensions are experimental and may still change while the feature matures.
+A GLSP server can optionally expose a [Model Context Protocol (MCP)]({{< relref "mcp" >}}) server alongside the GLSP protocol, so that AI agents can query and modify the diagram. Setting it up is an interplay between the client and the server over the `initialize` exchange:
+
+1. The client opts in by adding an `mcpServer` configuration to its `InitializeParameters` (the `McpInitializeParameters` extension). The presence of the key is the opt-in signal: an empty object enables the MCP server with defaults, and omitting the key disables it. The client may set behavioral fields such as the `port`, `route`, and `name`, and tuning options such as the data-exposure mode and the agent persona.
+2. On a request that carries an `mcpServer` key, the server starts its MCP server, merging the client-provided fields with its own deploy-time defaults. Security-sensitive fields such as the network binding and host allowlist are controlled by the server alone and cannot be set from the request.
+3. The server reports the resolved server back in its `InitializeResult` (the `McpInitializeResult` extension), announcing the `name`, `url`, and optional `headers`.
+4. The client, or its IDE integration, connects its MCP client to that announced `url`.
+
+These extensions are experimental and may still change while the feature matures.
 
 <details open><summary>Code</summary>
 
@@ -1741,49 +1748,6 @@ interface SelectAllAction extends Action {
 
 </details>
 
-#### 2.8.4. Editor Context
-
-GLSP requests are bidirectional: in addition to the client querying the server, the server can also send request actions to the client and await a response. The optional `timeout` field on [`RequestAction`](#2121-requestaction) bounds how long the sender waits. A common case is the server asking the client for the current [`EditorContext`](#238-editorcontext) snapshot. More specific queries such as `GetSelectionAction` and `GetViewportAction` (reused from Sprotty) follow the same request/response pattern.
-
-##### 2.8.4.1. GetEditorContextAction
-
-Sent from the server to the client to request the current editor context. The response is an `EditorContextResult` carrying a snapshot of the client state at the time the response is generated.
-
-<details open><summary>Code</summary>
-
-```typescript
-interface GetEditorContextAction extends RequestAction<EditorContextResult> {
-    /**
-     * The kind of the action.
-     */
-    kind = 'getEditorContext';
-}
-```
-
-</details>
-
-##### 2.8.4.2. EditorContextResult
-
-Response to a `GetEditorContextAction` containing a snapshot of the client-side editor state. The server should not assume that these values are still current when it processes the response, as the client state may have changed in the meantime.
-
-<details open><summary>Code</summary>
-
-```typescript
-interface EditorContextResult extends ResponseAction {
-    /**
-     * The kind of the action.
-     */
-    kind = 'editorContextResult';
-
-    /**
-     * The editor context snapshot.
-     */
-    editorContext: EditorContext;
-}
-```
-
-</details>
-
 ### 2.9. Element Hover
 
 #### 2.9.1. RequestPopupModelAction
@@ -2961,6 +2925,49 @@ interface TriggerEdgeCreationAction extends Action {
      * Custom arguments.
      */
     args?: Args;
+}
+```
+
+</details>
+
+### 2.20. Editor Context
+
+While most requests flow from the client to the server, the server can also send request actions to the client and await a response. The most common case is the server asking the client for its current [`EditorContext`](#238-editorcontext) snapshot. This is a server-initiated request. The client itself does not need it, since it has the editor context directly.
+
+#### 2.20.1. GetEditorContextAction
+
+Sent from the server to the client to request the current editor context. The response is an `EditorContextResult` carrying a snapshot of the client state at the time the response is generated.
+
+<details open><summary>Code</summary>
+
+```typescript
+interface GetEditorContextAction extends RequestAction<EditorContextResult> {
+    /**
+     * The kind of the action.
+     */
+    kind = 'getEditorContext';
+}
+```
+
+</details>
+
+#### 2.20.2. EditorContextResult
+
+Response to a `GetEditorContextAction` containing a snapshot of the client-side editor state. The server should not assume that these values are still current when it processes the response, as the client state may have changed in the meantime.
+
+<details open><summary>Code</summary>
+
+```typescript
+interface EditorContextResult extends ResponseAction {
+    /**
+     * The kind of the action.
+     */
+    kind = 'editorContextResult';
+
+    /**
+     * The editor context snapshot.
+     */
+    editorContext: EditorContext;
 }
 ```
 

--- a/content/documentation/protocol/content.md
+++ b/content/documentation/protocol/content.md
@@ -31,6 +31,11 @@ interface GLSPClient {
     readonly currentState: ClientState;
 
     /**
+     * Event that is fired whenever the client state changes.
+     */
+    readonly onCurrentStateChanged: Event<ClientState>;
+
+    /**
      * Initializes the client and the server connection. During the start procedure the client is in the
      * `Starting` state and will transition to either `Running` or `StartFailed`. Calling this method
      *  if the client is already running has no effect.
@@ -82,9 +87,11 @@ interface GLSPClient {
     disposeClientSession(params: DisposeClientSessionParameters): Promise<void>;
 
     /**
-     * Send a `shutdown` notification to the server.
+     * Send a `shutdown` notification to the server. New implementations should return a
+     * `Promise<void>` that resolves once the notification has been flushed to the wire, so
+     * callers disposing the connection immediately afterwards don't race the pending notification.
      */
-    shutdownServer(): void;
+    shutdownServer(): Promise<void> | void;
 
     /**
      * Stops the client and disposes unknown resources. During the stop procedure the client is in the `Stopping` state and will
@@ -159,7 +166,7 @@ In GLSP we provide a default client implementation based on [JSON-RPC messages](
 
 **Initialize Request**
 
-The `initialize` request has to be the first request from the client to the server. Until the server has responded with an `InitializeResult` no other request or notification can be handled and is expected to throw an error. A client is uniquely identified by an `applicationId` and has to specify on which `protocolVersion` it is based on. In addition, custom arguments can be provided in the `args` map to allow for custom initialization behavior on the server. The request returns an `InitializeResult` that encapsulates server information and capabilities. The `InitializeResult` is used inform the client about the action kinds that the server can handle for a specific `diagramType`.
+The `initialize` request has to be the first request from the client to the server. Until the server has responded with an `InitializeResult` no other request or notification can be handled and is expected to throw an error. A client is uniquely identified by an `applicationId` and has to specify on which `protocolVersion` it is based on (the current protocol version is `1.0.0`). In addition, custom arguments can be provided in the `args` map to allow for custom initialization behavior on the server. The request returns an `InitializeResult` that encapsulates server information and capabilities. The `InitializeResult` is used inform the client about the action kinds that the server can handle for a specific `diagramType`.
 
 <details open><summary>Code</summary>
 
@@ -292,7 +299,7 @@ interface ActionMessage<A extends Action = Action> {
     /**
      * The action to execute.
      */
-    Action: A;
+    action: A;
 }
 ```
 
@@ -327,6 +334,12 @@ interface RequestAction<Res extends ResponseAction> extends Action {
      * Unique id for this request. In order to match a response to this request, the response needs to have the same id.
      */
     requestId: string;
+
+    /**
+     * Optional timeout in milliseconds. When set, the sender controls how long the receiver waits for a response
+     * before the request is rejected.
+     */
+    timeout?: number;
 }
 ```
 
@@ -368,7 +381,7 @@ interface RejectAction extends ResponseAction {
     /**
      * Optional additional details.
      */
-    detail?: JsonAny;
+    detail?: string;
 }
 ```
 
@@ -389,6 +402,11 @@ interface Operation extends Action {
      * Discriminator property to make operations distinguishable from plain Actions.
      */
     isOperation: true;
+
+    /**
+     * Optional custom arguments.
+     */
+    args?: Args;
 }
 
 /**
@@ -751,6 +769,16 @@ interface EditorContext {
     readonly lastMousePosition?: Point;
 
     /**
+     * The current viewport (scroll position and zoom level).
+     */
+    readonly viewport?: Viewport;
+
+    /**
+     * The bounds of the canvas element in the browser.
+     */
+    readonly canvasBounds?: Bounds;
+
+    /**
      * Custom arguments.
      */
     readonly args?: Args;
@@ -786,6 +814,45 @@ interface LabeledAction {
 
 </details>
 
+#### 2.3.10. LayoutData
+
+Data computed by the client-side layouter for a model element.
+
+<details open><summary>Code</summary>
+
+```typescript
+interface LayoutData {
+    /**
+     * The computed minimum size of the element.
+     */
+    computedDimensions?: Dimension;
+}
+```
+
+</details>
+
+#### 2.3.11. ElementAndLayoutData
+
+The `ElementAndLayoutData` type is used to associate new layout data with a model element, which is referenced via its id.
+
+<details open><summary>Code</summary>
+
+```typescript
+interface ElementAndLayoutData {
+    /**
+     * The identifier of the element.
+     */
+    elementId: string;
+
+    /**
+     * The data provided by the layouter.
+     */
+    layoutData: LayoutData;
+}
+```
+
+</details>
+
 ### 2.4 Model Data
 
 #### 2.4.1. RequestModelAction
@@ -804,7 +871,7 @@ interface RequestModelAction extends RequestAction<SetModelAction> {
   /**
    * Additional options used to compute the graphical model.
    */
-  options?: { [key: string]: string });
+  options?: Args;
 }
 ```
 
@@ -925,10 +992,12 @@ interface SetDirtyStateAction extends Action {
     isDirty: boolean;
 
     /**
-     * A string indicating the reason for the dirty state change e.g 'operation', 'undo' ...
+     * Indicates the reason for the dirty state change.
      */
-    reason?: string;
+    reason?: DirtyStateChangeReason;
 }
+
+type DirtyStateChangeReason = 'operation' | 'undo' | 'redo' | 'save' | 'external';
 ```
 
 </details>
@@ -942,21 +1011,16 @@ Typically the `ExportSvgAction` is handled directly on client side.
 <details open><summary>Code</summary>
 
 ```typescript
-interface ExportSvgAction extends ResponseAction {
+interface RequestExportSvgAction extends RequestAction<ExportSvgAction> {
     /**
      * The kind of the action.
      */
-    kind = 'exportSvg';
+    kind = 'requestExportSvg';
 
     /**
-     * The diagram GModel as serializable SVG.
+     * Optional configuration options for the SVG export.
      */
-    svg: string;
-
-    /**
-     * Id corresponding to the request this action responds to.
-     */
-    responseId: string;
+    options?: ExportSvgOptions;
 }
 ```
 
@@ -989,7 +1053,16 @@ interface ExportSvgAction extends ResponseAction {
      */
     responseId: string;
 }
+
+interface ExportSvgOptions {
+    /**
+     * If set to `false`, applied diagram styles are not copied to the exported SVG.
+     */
+    skipCopyStyles?: boolean;
+}
 ```
+
+</details>
 
 ### 2.6. Model Layout
 
@@ -1051,6 +1124,21 @@ interface ComputedBoundsAction extends ResponseAction {
      * The route of the model elements.
      */
     routes?: ElementAndRoutingPoints[];
+
+    /**
+     * The layout data of the model elements.
+     */
+    layoutData?: ElementAndLayoutData[];
+
+    /**
+     * The current bounds of the canvas at time of layout.
+     */
+    canvasBounds?: Bounds;
+
+    /**
+     * The current viewport information at time of layout.
+     */
+    viewport?: Viewport;
 }
 ```
 
@@ -1060,7 +1148,7 @@ interface ComputedBoundsAction extends ResponseAction {
 
 Triggers a request for layout on the client. The handler of this request can collect client-side model information, such as viewport data, before sending a `LayoutOperation` to the server.
 
-<details open><summary Code></summary>
+<details open><summary>Code</summary>
 
 ```typescript
 interface TriggerLayoutAction extends Action {
@@ -1237,7 +1325,7 @@ interface StatusAction extends Action {
     /**
      * The severity of the status.
      */
-    severity: SeverityLeel;
+    severity: SeverityLevel;
 
     /**
      * The message describing the status.
@@ -1279,7 +1367,7 @@ interface MessageAction extends Action {
     /**
      * Further details on the message.
      */
-    details: string;
+    details?: string;
 }
 ```
 
@@ -1739,7 +1827,7 @@ interface ResolveNavigationTargetAction extends RequestAction<SetResolvedNavigat
 
 </details>
 
-#### 2.11.4. SetResolvedNavigationTargetAction
+#### 2.11.5. SetResolvedNavigationTargetAction
 
 An action sent from the server in response to a `ResolveNavigationTargetAction`. The response contains the resolved element ids for the given target and may contain additional information in the `args` property.
 
@@ -1766,7 +1854,7 @@ interface SetResolvedNavigationTargetAction extends ResponseAction {
 
 </details>
 
-#### 2.11.5. NavigateToExternalTargetAction
+#### 2.11.6. NavigateToExternalTargetAction
 
 If a navigation target cannot be resolved or the resolved target is something that is not part of our source model, e.g., a separate documentation file, a `NavigateToExternalTargetAction` may be sent. Since the target it outside of the model scope such an action would be typically handled by an integration layer (such as the surrounding IDE).
 
@@ -2078,7 +2166,7 @@ The client sends a `ChangeContainerOperation` to the server to request the execu
 <details open><summary>Code</summary>
 
 ```typescript
-interface ChangeContainerOperation implements Operation {
+interface ChangeContainerOperation extends Operation {
     /**
      * The kind of the action.
      */
@@ -2097,7 +2185,7 @@ interface ChangeContainerOperation implements Operation {
     /**
      * The graphical location.
      */
-    location?: string;
+    location?: Point;
 }
 ```
 
@@ -2204,7 +2292,7 @@ interface ResponseError {
     /**
      * Additional custom data, e.g., a serialized stacktrace.
      */
-    readonly data: Object;
+    readonly data: Record<string, unknown>;
 }
 
 namespace ValidationStatus {
@@ -2578,10 +2666,30 @@ interface TriggerNodeCreationAction extends Action {
     elementTypeId: string;
 
     /**
+     * An optional ghost element that schematically represents the node that may be created.
+     * It is not guaranteed that the created element will match the ghost element exactly.
+     */
+    ghostElement?: GhostElement;
+
+    /**
      * Custom arguments.
      */
     args?: Args;
 }
+
+/**
+ * A ghost element describes an element that may be rendered as a schematic visualization
+ * of an element that may be inserted during creation.
+ */
+interface GhostElement {
+    /**
+     * Either a reference to an existing element by id or a `GModelElementSchema`.
+     */
+    template: ElementTemplate;
+    dynamic?: boolean;
+}
+
+type ElementTemplate = string | GModelElementSchema;
 ```
 
 </details>


### PR DESCRIPTION
- Add an MCP documentation section covering enablement, architecture,
  tool-platform integration, and security, linking to the server-mcp docs
- Include a high-level MCP architecture diagram (SVG)
- Document the experimental mcpServer opt-in on InitializeParameters and
  the announced server URL on InitializeResult
- Add the generic export pipeline (RequestExportAction/ExportResultAction
  with PNG support) and deprecate the SVG-only export actions
- Add the OriginViewportAction and MoveViewportAction viewport actions
- Add GetEditorContextAction/EditorContextResult and note server-to-client
  requests


Also: Sync protocol documentation with current GLSP client protocol
- Replace the RequestExportSvgAction code block that wrongly showed the
  ExportSvgAction body and kind
- Correct ChangeContainerOperation to extend Operation with a Point location
- Type RejectAction.detail as string and RequestModelAction.options as Args
- Renumber the duplicate 2.11.4 navigation action headings
- Fix the SeverityLevel typo, the ActionMessage action field, and broken
  details/summary tags
- Add fields that landed since the doc was written: RequestAction.timeout,
  Operation.args, EditorContext viewport/canvasBounds, ComputedBoundsAction
  layout/canvas/viewport, GLSPClient.onCurrentStateChanged, ghostElement
- Note shutdownServer returns a promise-or-void and the protocol version
  is 1.0.0
- Define the referenced LayoutData, ElementAndLayoutData and
  ExportSvgOptions types

Fixes [#1673](https://github.com/eclipse-glsp/glsp/issues/1673)