### PR TITLE
Link PR preview comment directly to index.html

### DIFF
--- a/.github/workflows/pr-preview-deploy.yml
+++ b/.github/workflows/pr-preview-deploy.yml
@@ -67,4 +67,4 @@ jobs:
           header: pr-preview
           number: ${{ steps.pr.outputs.number }}
           message: |
-            🚀 **Website preview deployed to** ${{ steps.preview.outputs.deployment-url }}
+            🚀 **Website preview deployed to** ${{ steps.preview.outputs.deployment-url }}index.html


### PR DESCRIPTION
GitHub Pages does not serve the directory index for the preview path, so the bare `.../pr-<n>/` URL 404s. Point the comment at `index.html` (deployment-url already ends with a slash) so the link resolves.